### PR TITLE
Fix mobs fleeing

### DIFF
--- a/src/game/PointMovementGenerator.cpp
+++ b/src/game/PointMovementGenerator.cpp
@@ -116,10 +116,26 @@ template void PointMovementGenerator<Creature>::Reset(Creature&);
 template bool PointMovementGenerator<Player>::Update(Player&, const uint32& diff);
 template bool PointMovementGenerator<Creature>::Update(Creature&, const uint32& diff);
 
+void AssistanceMovementGenerator::Initialize(Unit& unit)
+{
+    if (unit.hasUnitState(UNIT_STAT_CAN_NOT_REACT | UNIT_STAT_NOT_MOVE))
+        return;
+    
+    if (!unit.IsStopped())
+        unit.StopMoving();
+    
+    unit.addUnitState(UNIT_STAT_ROAMING | UNIT_STAT_ROAMING_MOVE);
+    Movement::MoveSplineInit init(unit);
+    init.MoveTo(i_x, i_y, i_z, m_generatePath);
+    //Slow down the mob that is running for assistance
+    init.SetVelocity(0.9f);
+    init.Launch();
+}
+
 void AssistanceMovementGenerator::Finalize(Unit& unit)
 {
     unit.clearUnitState(UNIT_STAT_ROAMING | UNIT_STAT_ROAMING_MOVE);
-
+    
     ((Creature*)&unit)->SetNoCallAssistance(false);
     ((Creature*)&unit)->CallAssistance();
     if (unit.isAlive())

--- a/src/game/PointMovementGenerator.h
+++ b/src/game/PointMovementGenerator.h
@@ -55,7 +55,7 @@ class MANGOS_DLL_SPEC AssistanceMovementGenerator
             PointMovementGenerator<Creature>(0, _x, _y, _z, true) {}
 
         MovementGeneratorType GetMovementGeneratorType() const override { return ASSISTANCE_MOTION_TYPE; }
-	void Initialize(Unit&) override;
+        void Initialize(Unit&) override;
         void Finalize(Unit&) override;
 };
 

--- a/src/game/PointMovementGenerator.h
+++ b/src/game/PointMovementGenerator.h
@@ -41,7 +41,7 @@ class MANGOS_DLL_SPEC PointMovementGenerator
         MovementGeneratorType GetMovementGeneratorType() const override { return POINT_MOTION_TYPE; }
 
         bool GetDestination(float& x, float& y, float& z) const { x = i_x; y = i_y; z = i_z; return true; }
-    private:
+    protected:
         uint32 id;
         float i_x, i_y, i_z;
         bool m_generatePath;
@@ -55,6 +55,7 @@ class MANGOS_DLL_SPEC AssistanceMovementGenerator
             PointMovementGenerator<Creature>(0, _x, _y, _z, true) {}
 
         MovementGeneratorType GetMovementGeneratorType() const override { return ASSISTANCE_MOTION_TYPE; }
+	void Initialize(Unit&) override;
         void Finalize(Unit&) override;
 };
 


### PR DESCRIPTION
This slows down the mobs fleeing as seen in #2. Perhaps a config value should added for how quick they should run because i couldn't figure out at what the modifier should be. We could also use the `SetWalk()` instead of how it's done right now, i remember booty bay bucaneers walking away, don't know about the other mobs though.
