### PR TITLE
Updated libmpq to create config.h

### DIFF
--- a/dep/CMakeLists.txt
+++ b/dep/CMakeLists.txt
@@ -32,10 +32,10 @@ include(ExternalProject)
 ExternalProject_Add(mympqtmp
   PREFIX "./"
   SOURCE_DIR "${CMAKE_SOURCE_DIR}/dep/libmpq/"
+  INSTALL_DIR "${CMAKE_BINARY_DIR}/lib"
   # This is for the CONFIGURE_COMMAND to have the right working dir
   BINARY_DIR "${CMAKE_SOURCE_DIR}/dep/libmpq/"
   CONFIGURE_COMMAND "${CMAKE_SOURCE_DIR}/dep/libmpq/autogen.sh"
-  BUILD_COMMAND ""
+  BUILD_COMMAND "${CMAKE_SOURCE_DIR}/dep/libmpq/configure"
   INSTALL_COMMAND ""
 )
-


### PR DESCRIPTION
Earlier it wouldn't generate the config.h as it should, now does. This still feels like a massive cludge though. We should probably have our own feature tests to decide what should be in there. Don't know cmake good enough to add that though. Should be a todo.
