### PR TITLE
[Core] Fix crash on shutdown related to unloading SD2 library

### DIFF
--- a/src/game/ScriptMgr.cpp
+++ b/src/game/ScriptMgr.cpp
@@ -91,7 +91,6 @@ ScriptMgr::ScriptMgr() :
 
 ScriptMgr::~ScriptMgr()
 {
-    UnloadScriptLibrary();
 }
 
 // /////////////////////////////////////////////////////////

--- a/src/mangosd/Master.cpp
+++ b/src/mangosd/Master.cpp
@@ -48,6 +48,7 @@
 #include "revision_sql.h"
 #include "MassMailMgr.h"
 #include "DBCStores.h"
+#include "ScriptMgr.h"
 #ifdef ENABLE_SOAP
 #include "MaNGOSsoap.h"
 #endif
@@ -431,6 +432,11 @@ int Master::Run()
 
         delete cliThread;
     }
+
+    // This is done to make sure that we cleanup our so file before it's 
+    // unloaded automatically, since the ~ScriptMgr() is called to late 
+    // as it's allocated with static storage.
+    sScriptMgr.UnloadScriptLibrary();
 
     ///- Exit the process with specified return value
     return World::GetExitCode();


### PR DESCRIPTION
Would be nice if someone could test and confirm this one.
