### PR TITLE
Crash on wrong db version

### DIFF
--- a/src/game/SharedDefines.h
+++ b/src/game/SharedDefines.h
@@ -28,6 +28,9 @@
 #include "Platform/Define.h"
 #include <cassert>
 
+#ifndef MANGOS
+#define MANGOS
+#endif /* MANGOS */
 #define CLASSIC
 
 enum Gender

--- a/src/game/SharedDefines.h
+++ b/src/game/SharedDefines.h
@@ -28,7 +28,6 @@
 #include "Platform/Define.h"
 #include <cassert>
 
-#define MANGOS
 #define CLASSIC
 
 enum Gender

--- a/src/shared/Threading.cpp
+++ b/src/shared/Threading.cpp
@@ -191,7 +191,9 @@ void Thread::resume()
 
 ACE_THR_FUNC_RETURN Thread::ThreadTask(void* param)
 {
-    Runnable* _task = (Runnable*)param;
+    Runnable* _task = static_cast<Runnable*>(param);
+    _task->incReference();
+    
     _task->run();
 
     // task execution complete, free referecne added at


### PR DESCRIPTION
The general gut feeling is that the Runnable shouldn't ref-count itself, but rather eg.
ACE_Strong_Bound_Ptr should be used for that purpose to ensure deletion at the correct
time. This also ensures that we can check if the pointer is available or not, currently that's
not possible at all as we delete this; Comments?

Also remove #define MANGOS as that's defined on the command line when building
