### PR TITLE
[Core/CMake] Fix one warning and suppress a few when using cmake 3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,9 @@
 cmake_minimum_required(VERSION 2.8)
 # Until CMake 3.0 is the standard
 # And a solution to set_directory_properties is found.
-cmake_policy(SET CMP0043 OLD)
+if(POLICY CMP0043)
+    cmake_policy(SET CMP0043 OLD)
+endif()
 
 project(MaNGOS)
 set(MANGOS_VERSION 0.20)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,9 @@
 
 # CMake policies
 cmake_minimum_required(VERSION 2.8)
+# Until CMake 3.0 is the standard
+# And a solution to set_directory_properties is found.
+cmake_policy(SET CMP0043 OLD)
 
 project(MaNGOS)
 set(MANGOS_VERSION 0.20)
@@ -307,9 +310,8 @@ add_executable(genrev
   ${GENREV_SRC}
 )
 
-get_target_property(GENERATE_EXE genrev LOCATION)
 add_custom_target("revision.h" ALL
-  COMMAND ${GENERATE_EXE} ${CMAKE_SOURCE_DIR}
+  COMMAND $<TARGET_FILE:genrev> ${CMAKE_SOURCE_DIR}
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   DEPENDS genrev
 )
@@ -403,6 +405,8 @@ if(USE_STD_MALLOC)
 endif()
 
 set_directory_properties(PROPERTIES COMPILE_DEFINITIONS "${DEFINITIONS}")
+#Something like this is what i've imagined with the new generator expressions in cmake 3.0 / lfx
+#set_directory_properties(PROPERTIES COMPILE_DEFINITIONS "$<$<CONFIG:Release>:"${DEFINITIONS} ${DEFINITIONS_RELEASE}">$<$<CONFIG:Debug>:"${DEFINITIONS} ${DEFINITIONS_DEBUG}">")
 set_directory_properties(PROPERTIES COMPILE_DEFINITIONS_RELEASE "${DEFINITIONS_RELEASE}")
 set_directory_properties(PROPERTIES COMPILE_DEFINITIONS_DEBUG "${DEFINITIONS_DEBUG}")
 

--- a/src/framework/CMakeLists.txt
+++ b/src/framework/CMakeLists.txt
@@ -108,9 +108,6 @@ add_library(${LIBRARY_NAME} STATIC
   ${LIBRARY_SRCS}
 )
 
-if(NOT TBB_USE_EXTERNAL)
-  add_dependencies(${LIBRARY_NAME} TBB_Project)
-endif()
 if(NOT ACE_USE_EXTERNAL)
   add_dependencies(${LIBRARY_NAME} ACE_Project)
 endif()


### PR DESCRIPTION
Removes a old reference to TBB and uses a generator expression instead of get_property as adviced by cmake. 

Also currently CMP0043 is set to the old behaviour until set_directory_properties can be fixed.
