### PR TITLE
[Core/SD2] Make SD2 optional and fix a bug in config.h.cmake

### DIFF
--- a/config.h.cmake
+++ b/config.h.cmake
@@ -22,10 +22,12 @@
  * and lore are copyrighted by Blizzard Entertainment, Inc.
  */
 
-#ifndef HAVE_CONFIG_H
-#define HAVE_CONFIG_H
+#ifndef MANGOS_CONFIG_H
+#define MANGOS_CONFIG_H
 
+#ifndef HAVE_ACE_STACK_TRACE_H
 #cmakedefine HAVE_ACE_STACK_TRACE_H
+#endif /* HAVE_ACE_STACK_TRACE_H */
 
 #cmakedefine USE_MULTI_THREAD_MAP
 
@@ -37,4 +39,4 @@
 
 #define VERSION "${MANGOS_VERSION}"
 
-#endif /* HAVE_CONFIG_H */
+#endif /* MANGOS_CONFIG_H */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,5 +61,7 @@ if(BUILD_TOOLS)
 endif()
 
 #-----------------------------------------------------------------------------
-# Build the mangos-zero script library
-add_subdirectory(scripts)
+# Build the mangos-zero script library if wished for
+if(ENABLE_SD2)
+    add_subdirectory(scripts)
+endif()

--- a/src/game/World.cpp
+++ b/src/game/World.cpp
@@ -1237,6 +1237,7 @@ void World::SetInitialWorldSettings()
     sLog.outString("Loading CreatureEventAI Scripts...");
     sEventAIMgr.LoadCreatureEventAI_Scripts();
 
+#ifdef ENABLE_SD2
     sLog.outString("Initializing Scripts...");
     switch (sScriptMgr.LoadScriptLibrary(MANGOS_SCRIPT_NAME))
     {
@@ -1253,6 +1254,9 @@ void World::SetInitialWorldSettings()
             sLog.outError("Scripting library build for old mangosd revision. You need rebuild it.");
             break;
     }
+#else /* ENABLE_SD2 */
+    sLog.outError("SD2 is enabled but wasn't included during compilation, not activating it.");
+#endif /* ENABLE_SD2 */
 
 #ifdef ENABLE_ELUNA
     ///- Initialize Lua Engine


### PR DESCRIPTION
This should fix a bug with enabling and disabling SD2/Eluna when compiling. 
