### PR TITLE
[CMake] Fix tools to build again, although in 64bit mode for now

### DIFF
--- a/src/tools/Movemap-Generator/CMakeLists.txt
+++ b/src/tools/Movemap-Generator/CMakeLists.txt
@@ -31,6 +31,9 @@ if(WIN32 AND MSVC)
     add_definitions(-DNO_vsnprintf)
 endif()
 
+# For 64bit definitions in Detour
+add_definitions(-DDT_POLYREF64)
+
 include_directories(
     "${CMAKE_SOURCE_DIR}/src"
     "${CMAKE_SOURCE_DIR}/src/shared"


### PR DESCRIPTION
Needs to be looked over and have we started supporting only 64bit builds?
