### PR TITLE
Fixing Group Loot Issue

### DIFF
--- a/src/game/Creature.cpp
+++ b/src/game/Creature.cpp
@@ -154,6 +154,7 @@ Creature::Creature(CreatureSubtype subtype) : Unit(),
     hasBeenLootedOnce = false;
     assignedLooter = 0;
 
+	m_killedTime = 0;
     m_regenTimer = 200;
     m_valuesCount = UNIT_END;
 
@@ -231,6 +232,16 @@ void Creature::RemoveCorpse()
     StopGroupLoot();
 
     loot.clear();
+
+	/* Loot data */
+	m_killedTime = 0;
+    hasBeenLootedOnce = false;
+    assignedLooter = 0;
+	m_lootGroupRecipientId = 0;
+	m_lootRecipientGuid.Clear();
+
+	RemoveFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_TAPPED);
+
     uint32 respawnDelay = 0;
 
     if (AI())
@@ -1049,7 +1060,6 @@ void Creature::SetLootRecipient(Unit* unit)
     {
         m_lootRecipientGuid.Clear();
         m_lootGroupRecipientId = 0;
-        RemoveFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_TAPPED);
         return;
     }
 
@@ -1064,7 +1074,7 @@ void Creature::SetLootRecipient(Unit* unit)
     if (Group* group = player->GetGroup())
         { m_lootGroupRecipientId = group->GetId(); }
 
-    SetFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_TAPPED);
+	SetFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_TAPPED);
 }
 
 void Creature::SaveToDB()
@@ -1623,9 +1633,8 @@ void Creature::SetDeathState(DeathState s)
 
         SetMeleeDamageSchool(SpellSchools(GetCreatureInfo()->DamageSchool));
 
-        // Dynamic flags may be adjusted by spells. Clear them
-        // first and let spell from *addon apply where needed.
-        SetUInt32Value(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_NONE);
+        // Dynamic flags must be set on Tapped by default.
+		SetUInt32Value(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_NONE);
         LoadCreatureAddon(true);
 
         // Flags after LoadCreatureAddon. Any spell in *addon

--- a/src/game/Creature.h
+++ b/src/game/Creature.h
@@ -635,18 +635,58 @@ class MANGOS_DLL_SPEC Creature : public Unit
         virtual void DeleteFromDB();                        // overwrited in Pet
         static void DeleteFromDB(uint32 lowguid, CreatureData const* data);
 
+		/// Represent the loots available on the creature.
         Loot loot;
+
+		/// Indicates whether the creature has has been pickpocked.
         bool lootForPickPocketed;
+
+		/// Indicates whether the creature has been checked.
         bool lootForBody;
+
+		/// Indicates whether the creature has been skinned.
         bool lootForSkin;
 
+		/**
+		* Method preparing the creature for the loot state. Based on the previous loot state, the loot ID provided in the database and the creature's type,
+		* this method updates the state of the creature for loots.
+		*
+		* At the end of this method, the creature loot state may be:
+		* Lootable: UNIT_DYNFLAG_LOOTABLE
+		* Skinnable: UNIT_FLAG_SKINNABLE
+		* Not lootable: No flag
+		*/
         void PrepareBodyLootState();
+
+		/**
+		* function returning the GUID of the loot recipient (a player GUID).
+		*
+		* \return ObjectGuid Player GUID.
+		*/
         ObjectGuid GetLootRecipientGuid() const { return m_lootRecipientGuid; }
+
+		/**
+		* function returning the group recipient ID.
+		*
+		* \return uint32 Group ID.
+		*/
         uint32 GetLootGroupRecipientId() const { return m_lootGroupRecipientId; }
         Player* GetLootRecipient() const;                   // use group cases as prefered
         Group* GetGroupLootRecipient() const;
         bool IsTappedBy(Player const* player) const;
-        bool HasLootRecipient() const { return m_lootGroupRecipientId || m_lootRecipientGuid; }
+
+		/**
+		* function indicating whether the whether the creature has a looter recipient defined (either a group ID, either a player GUID).
+		*
+		* \return boolean true if the creature has a recipient defined, false otherwise.
+		*/
+		bool HasLootRecipient() const { return m_lootGroupRecipientId || m_lootRecipientGuid; }
+
+		/**
+		* function indicating whether the recipient is a group.
+		* 
+		* \return boolean true if the creature's recipient is a group, false otherwise.
+		*/
         bool IsGroupLootRecipient() const { return m_lootGroupRecipientId; }
         void SetLootRecipient(Unit* unit);
         void AllLootRemovedFromCorpse();
@@ -694,6 +734,16 @@ class MANGOS_DLL_SPEC Creature : public Unit
 
         uint32 GetRespawnDelay() const { return m_respawnDelay; }
         void SetRespawnDelay(uint32 delay) { m_respawnDelay = delay; }
+
+		/**
+		* Returns the time when the creature has been killed.
+		*/
+		time_t const& GetKilledTime() const { return m_killedTime; }
+
+		/**
+		* Set the time when the creature has been killed.
+		*/
+		void SetKilledTime(time_t time) { m_killedTime = time; }
 
         float GetRespawnRadius() const { return m_respawnradius; }
         void SetRespawnRadius(float dist) { m_respawnradius = dist; }
@@ -773,6 +823,8 @@ class MANGOS_DLL_SPEC Creature : public Unit
         uint32 m_corpseDelay;                               // (secs) delay between death and corpse disappearance
         uint32 m_aggroDelay;                                // (msecs)delay between respawn and aggro due to movement
         float m_respawnradius;
+
+		time_t m_killedTime;								// Exact time of the death.
 
         CreatureSubtype m_subtype;                          // set in Creatures subclasses for fast it detect without dynamic_cast use
         void RegeneratePower();

--- a/src/game/Group.cpp
+++ b/src/game/Group.cpp
@@ -191,6 +191,7 @@ bool Group::LoadMemberFromDB(uint32 guidLow, uint8 subgroup, bool assistant)
 
     member.group     = subgroup;
     member.assistant = assistant;
+	member.joinTime = time(NULL);
     m_memberSlots.push_back(member);
 
     SubGroupCounterIncrease(subgroup);
@@ -1152,6 +1153,7 @@ bool Group::_addMember(ObjectGuid guid, const char* name, bool isAssistant, uint
     member.name      = name;
     member.group     = group;
     member.assistant = isAssistant;
+	member.joinTime = time(NULL);
     m_memberSlots.push_back(member);
 
     SubGroupCounterIncrease(group);

--- a/src/game/Group.h
+++ b/src/game/Group.h
@@ -158,12 +158,22 @@ struct InstanceGroupBind
 class MANGOS_DLL_SPEC Group
 {
     public:
+		/**
+		* Struct MemberSlot
+		* Represent a member of a group with some of its caracteristics
+		*/
         struct MemberSlot
         {
+			/* GUID of the player. */
             ObjectGuid  guid;
+			/* Name of the player. */
             std::string name;
+			/* Group of the player. */
             uint8       group;
+			/* Indicates whether the player is assistant. */
             bool        assistant;
+			/* The time when the player has joined the group. */
+			time_t		joinTime;
         };
         typedef std::list<MemberSlot> MemberSlotList;
         typedef MemberSlotList::const_iterator member_citerator;
@@ -235,6 +245,20 @@ class MANGOS_DLL_SPEC Group
         }
 
         bool SameSubGroup(Player const* member1, Player const* member2) const;
+
+		/**
+		* Returns the joined time of a member if it exist.
+		* \param guid GUID of the player to look for.
+		* \return time_t representing the joined time for that player or NULL if it doesn't exist.
+		*/
+		time_t const& GetMemberSlotJoinedTime(ObjectGuid guid)
+		{
+			member_citerator mslot = _getMemberCSlot(guid);
+			if(mslot == m_memberSlots.end())
+				{ return NULL; }
+
+			return mslot->joinTime;
+		}
 
         MemberSlotList const& GetMemberSlots() const { return m_memberSlots; }
         GroupReference* GetFirstMember() { return m_memberMgr.getFirst(); }

--- a/src/game/LootHandler.cpp
+++ b/src/game/LootHandler.cpp
@@ -474,10 +474,12 @@ void WorldSession::DoLootRelease(ObjectGuid lguid)
             /* Copy creature loot to loot variable */
             loot = &pCreature->loot;
 
-            // update next looter
-            if (Group* group = pCreature->GetGroupLootRecipient())
-                if (group->GetLooterGuid() == player->GetObjectGuid())
-                    group->UpdateLooterGuid(pCreature);
+			/* Update for other players. */
+			if(!loot->isLooted())
+			{ 
+				pCreature->hasBeenLootedOnce = true;	
+				pCreature->MarkFlagUpdateForClient(UNIT_DYNAMIC_FLAGS);
+			}			
 
             /* We've completely looted the creature, mark it as available for skinning */
             if (loot->isLooted() && !pCreature->IsAlive())

--- a/src/game/LootMgr.h
+++ b/src/game/LootMgr.h
@@ -162,6 +162,24 @@ class LootStore
         bool HaveQuestLootFor(uint32 loot_id) const;
         bool HaveQuestLootForPlayer(uint32 loot_id, Player* player) const;
 
+		/**
+		* function which indicates whether there's at least one shared quest item dropped for a given player
+		*
+		* \param loot_id uint32 indicating the loot template id.
+		* \param player Player const* to the player that needs to get loot or not.
+		* \return bool if there's at least one Shared Quest Loot available.
+		*/
+		bool HaveSharedQuestLootForPlayer(uint32 loot_id, Player* player) const;
+
+		/**
+		* function which indicates whether there's at least one starting quest item dropped for a given player
+		*
+		* \param loot_id uint32 indicating the loot template id.
+		* \param player Player const* to the player that needs to get loot or not.
+		* \return bool if there's at least one Starting Quest Loot available.
+		*/
+		bool HaveStartingQuestLootForPlayer(uint32 loot_id, Player* player) const;
+
         LootTemplate const* GetLootFor(uint32 loot_id) const;
 
         char const* GetName() const { return m_name; }
@@ -192,6 +210,26 @@ class LootTemplate
         bool HasQuestDrop(LootTemplateMap const& store, uint8 GroupId = 0) const;
         // True if template includes at least 1 quest drop for an active quest of the player
         bool HasQuestDropForPlayer(LootTemplateMap const& store, Player const* player, uint8 GroupId = 0) const;
+
+		/**
+		* function which indicates whether there's at least one shared quest item dropped for a given player
+		*
+		* \param store LootTemplateMap const& which provides the source store of items drop.
+		* \param player Player const* to the player that needs to get loot or not.
+		* \param GroupId uint8 indicates the GroupId for the given LootTemplate (see database).
+		* \return bool if there's at least one Shared Quest Loot available.
+		*/
+		bool HasSharedQuestDropForPlayer(LootTemplateMap const& store, Player const* player, uint8 GroupId = 0) const;
+
+		/**
+		* function which indicates whether there's at least one starting quest item dropped for a given player
+		*
+		* \param store LootTemplateMap const& which provides the source store of items drop.
+		* \param player Player const* to the player that needs to get loot or not.
+		* \param GroupId uint8 indicates the GroupId for the given LootTemplate (see database).
+		* \return bool if there's at least one starting Quest Loot available.
+		*/
+		bool HasStartingQuestDropForPlayer(LootTemplateMap const& store, Player const* player, uint8 GroupId = 0) const;
 
         // Checks integrity of the template
         void Verify(LootStore const& store, uint32 Id) const;

--- a/src/game/Object.cpp
+++ b/src/game/Object.cpp
@@ -452,9 +452,6 @@ void Object::BuildValuesUpdate(uint8 updatetype, ByteBuffer* data, UpdateMask* u
                     /* If the creature has tapped flag but is tapped by us, remove the flag */
                     if (send_value & UNIT_DYNFLAG_TAPPED && is_tapped)
                         { send_value = send_value & ~UNIT_DYNFLAG_TAPPED; }
-                    /* If creature does not have tapped flag but is not tapped by us, set the flag */
-                    else if (!(send_value & UNIT_DYNFLAG_TAPPED) && !is_tapped)
-                        { send_value = send_value | UNIT_DYNFLAG_TAPPED; }
 
                     *data << send_value;
                 }
@@ -703,6 +700,14 @@ void Object::ApplyModPositiveFloatValue(uint16 index, float  val, bool apply)
     if (cur < 0)
         { cur = 0; }
     SetFloatValue(index, cur);
+}
+
+void Object::MarkFlagUpdateForClient(uint16 index)
+{
+	MANGOS_ASSERT(index < m_valuesCount || PrintIndexError(index, true));
+
+	m_changedValues[index] = true;
+	MarkForClientUpdate();
 }
 
 void Object::SetFlag(uint16 index, uint32 newFlag)

--- a/src/game/Object.h
+++ b/src/game/Object.h
@@ -262,6 +262,12 @@ class MANGOS_DLL_SPEC Object
             SetFloatValue(index, GetFloatValue(index) * (apply ? (100.0f + val) / 100.0f : 100.0f / (100.0f + val)));
         }
 
+		/**
+		* method to force the update of a given flag to the client. The method is checking the index before indicating the flags need an update.
+		*
+		* \param index uint16 of the flag to be updated.
+		*/
+		void MarkFlagUpdateForClient(uint16 index);
         void SetFlag(uint16 index, uint32 newFlag);
         void RemoveFlag(uint16 index, uint32 oldFlag);
 

--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -13960,77 +13960,93 @@ bool Player::isAllowedToLoot(Creature* creature)
                 { return false; } // We're not in a group, probably cheater
 
             /* We're in a group, get the loot type */
-            if (LootMethod loot_type = plr_group->GetLootMethod())
+			switch (plr_group->GetLootMethod())
             {
-                switch (loot_type)
-                {
-                        /* Free for all, let everyone loot it */
-                    case FREE_FOR_ALL:
-                        return true;
+				/* Free for all, let everyone loot it */
+                case FREE_FOR_ALL:
+					return true;
 
-                        /* Returns true for master looter, otherwise falls through to checks below */
-                    case MASTER_LOOT:
-                        /* Validate the group's looter's ObjectGuid against our own */
-                        if (plr_group->GetLooterGuid() == GetObjectGuid())
-                            { return true; }
+                /* Returns true for master looter, otherwise falls through to checks below */
+                case MASTER_LOOT:
+					/* Validate the group's looter's ObjectGuid against our own */
+                    return (plr_group->GetLooterGuid() == GetObjectGuid());
 
-                        /* These 3 systems all use the same kind of check to display loot,
-                           which is what we're doing here. Threshold checks are done elsewhere. */
-                    case GROUP_LOOT:
-                    case ROUND_ROBIN:
-                    case NEED_BEFORE_GREED:
-                        /* This is set to true after the looter (chosen below) has closed their loot window
-                         * If this is true, allow everyone else in the group to loot the corpse */
-                        if (creature->hasBeenLootedOnce)
-                            { return true; }
-                        /* If the assigned looter's GUID is equal to ours */
-                        else if (creature->assignedLooter == GetGUIDLow())
-                            { return true; }
-                        /* If the creature already has an assigned looter and that looter isn't us */
-                        else if (creature->assignedLooter != 0)
-                            { return false; }
+                /* These 3 systems all use the same kind of check to display loot,
+					which is what we're doing here. Threshold checks are done elsewhere. */
+                case GROUP_LOOT:
+                case ROUND_ROBIN:
+                case NEED_BEFORE_GREED:
+				{
+					uint32 loot_id = creature->GetCreatureInfo()->LootId;
 
-                        /* If we've reached here, there is only one exclusive, undecided looter */
+					/* Checking there's some loot defined. */
+					bool hasLoot = loot_id;
+					/* Checking if the creature may drop any quest loot for us. */
+					bool hasSharedLoot = LootTemplates_Creature.HaveSharedQuestLootForPlayer(loot_id, this);
+					/* Checking if there's any starting quest item available for this player. */
+					bool hasStartingQuestLoot = LootTemplates_Creature.HaveStartingQuestLootForPlayer(loot_id,  this);
 
-                        /* This is the player that will be given permission to loot */
-                        Player* final_looter = recipient;
+					/* If the player has joined the group after the creature has been killed, doesn't show up. */
+					if(creature->GetKilledTime() < plr_group->GetMemberSlotJoinedTime(GetObjectGuid()))
+						{ return false; }
+					/* If there's no loot, we return false. */
+					else if(!hasLoot)
+						{ return false; }
+					/* This is set to true after the looter (chosen below) has closed their loot window
+                    * If this is true, allow everyone else in the group to loot the corpse */
+                    else if (creature->hasBeenLootedOnce)
+						{ return true; }
+                    /* If the assigned looter's GUID is equal to ours */
+					else if (creature->assignedLooter == GetGUIDLow())
+						{ return true; }
+                    /* If the creature already has an assigned looter and that looter isn't us */					
+					else if (creature->assignedLooter != 0 && !hasSharedLoot && !hasStartingQuestLoot)
+						{ return false; }
 
-                        /* Iterate through the valid party members */
-                        Group::MemberSlotList slots = plr_group->GetMemberSlots();
-                        for (Group::MemberSlotList::iterator itr = slots.begin(); itr != slots.end(); ++itr)
+                    /* If we've reached here, there is only one exclusive, undecided looter */
+
+                    /* This is the player that will be given permission to loot */
+                    Player* final_looter = recipient;
+					
+					/* Iterate through the valid party members */
+					Group::MemberSlotList slots = plr_group->GetMemberSlots();
+					
+					for (Group::MemberSlotList::iterator itr = slots.begin(); itr != slots.end(); ++itr)
+                    {
+						/* Get the player data */
+                        if (Player* grp_plr = sObjectMgr.GetPlayer(itr->guid))
                         {
-                            /* Get the player data */
-                            if (Player* grp_plr = sObjectMgr.GetPlayer(itr->guid))
-                            {
-                                /* Player is disconnected */
-                                if (!grp_plr->IsInWorld())
-                                    { continue; }
+							/* Player is disconnected */
+                            if (!grp_plr->IsInWorld())
+								{ continue; }
 
-                                /* Check if the last time the player looted is less than the current final looter
-                                 * If the value is lower, it means it happened longer ago */
-                                if (final_looter->lastTimeLooted > grp_plr->lastTimeLooted)
-                                    { final_looter = grp_plr; }
-                            }
+							/* Player is too far from the creature. */
+							if(!grp_plr->IsWithinDist(creature, sWorld.getConfig(CONFIG_FLOAT_GROUP_XP_DISTANCE), false))
+								{ continue; }
+
+                            /* Check if the last time the player looted is less than the current final looter
+                             * If the value is lower, it means it happened longer ago */
+                            if (final_looter->lastTimeLooted > grp_plr->lastTimeLooted)
+								{ final_looter = grp_plr; }
                         }
+					}
 
-                        /* We have our looter, update their loot time */
-                        final_looter->lastTimeLooted = time(NULL);
-
-                        /* Update the creature with the looter that has been assigned to them */
-                        creature->assignedLooter = final_looter->GetGUIDLow();
-
-                        /* Finally, return if we are the assigned looter */
-                        uint32 flguid = final_looter->GetGUIDLow();
-                        uint32 myguid = GetGUIDLow();
-                        bool is_same = (flguid == myguid);
-                        return is_same;
-
-                        break;
-                        /* End of switch statement */
-                }
-            }
-            else
-                { return false; } // Something went wrong, avoid crash
+                    /* We have our looter, update their loot time */
+                    final_looter->lastTimeLooted = time(NULL);
+					
+					/* Update the creature with the looter that has been assigned to them */
+					creature->assignedLooter = final_looter->GetGUIDLow();
+					final_looter->GetGroup()->SetLooterGuid(final_looter->GetGUID());
+					
+					/* Finally, return if we are the assigned looter */
+					return (final_looter->GetGUIDLow() == GetGUIDLow() || hasSharedLoot || hasStartingQuestLoot);
+                    /* End of switch statement */
+				}
+				default:
+					// Something went wrong, avoid crash
+					
+					return false;
+			}
         }
         /* We're not in a group, check to make sure we're the recipient (prevent cheaters) */
         else if (recipient == this)

--- a/src/game/SharedDefines.h
+++ b/src/game/SharedDefines.h
@@ -2061,7 +2061,7 @@ enum UnitDynFlags
     UNIT_DYNFLAG_NONE                       = 0x0000,
     UNIT_DYNFLAG_LOOTABLE                   = 0x0001,
     UNIT_DYNFLAG_TRACK_UNIT                 = 0x0002,
-    UNIT_DYNFLAG_TAPPED                     = 0x0004,       // Lua_UnitIsTapped
+    UNIT_DYNFLAG_TAPPED                     = 0x0004,       // Lua_UnitIsTapped - Indicates the target as grey for the client.
     UNIT_DYNFLAG_ROOTED                     = 0x0008,
     UNIT_DYNFLAG_SPECIALINFO                = 0x0010,
     UNIT_DYNFLAG_DEAD                       = 0x0020,

--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -1125,6 +1125,7 @@ void Unit::JustKilledCreature(Creature* victim, Player* responsiblePlayer)
         { return; }                                             // Pets might have been unsummoned at this place, do not handle them further!
 
     /* ******************************** Prepare loot if can ************************************ */
+	victim->SetKilledTime(time(NULL));
     victim->DeleteThreatList();
     // only lootable if it has loot or can drop gold
     victim->PrepareBodyLootState();

--- a/src/game/WorldSession.h
+++ b/src/game/WorldSession.h
@@ -340,7 +340,17 @@ class MANGOS_DLL_SPEC WorldSession
         void HandleRepopRequestOpcode(WorldPacket& recvPacket);
         void HandleAutostoreLootItemOpcode(WorldPacket& recvPacket);
         void HandleLootMoneyOpcode(WorldPacket& recvPacket);
+
+		/**
+		* Method which handles the loot Opcode sent by the client, happens when the player is actually looting the object.
+		* It generates required loot on purpose.
+		*/
         void HandleLootOpcode(WorldPacket& recvPacket);
+
+		/**
+		* Method which handles the loot release opcode sent by the client, happens when the player has end looting the object.
+		* It will take care of the looting state of the object depending on the case.
+		*/
         void HandleLootReleaseOpcode(WorldPacket& recvPacket);
         void HandleLootMasterGiveOpcode(WorldPacket& recvPacket);
         void HandleWhoOpcode(WorldPacket& recvPacket);


### PR DESCRIPTION
- Everybody within a group will be able to loot any creature which is dropping a shared quest item
- Everybody within a group will be able to loot any creature which is dropping a starting quest item (if it drops at 100%)
- When a player release the corpse, other players of the group will be able to loot the creature as well (except if a member was not part of the group before the kill)
- Respawning creatures won't appear with a grey bar anymore
