### PR TITLE
Loot Handler fix, last revision

### DIFF
--- a/src/game/Creature.h
+++ b/src/game/Creature.h
@@ -738,7 +738,7 @@ class MANGOS_DLL_SPEC Creature : public Unit
 		/**
 		* Returns the time when the creature has been killed.
 		*/
-		time_t const& GetKilledTime() const { return m_killedTime; }
+		time_t GetKilledTime() const { return m_killedTime; }
 
 		/**
 		* Set the time when the creature has been killed.

--- a/src/game/GameObject.cpp
+++ b/src/game/GameObject.cpp
@@ -1784,8 +1784,7 @@ void GameObject::RollIfMineralVein()
     GameObjectInfo const* goinfo = ObjectMgr::GetGameObjectInfo(GetEntry());
     if (goinfo->chest.minSuccessOpens != 0 && goinfo->chest.maxSuccessOpens > goinfo->chest.minSuccessOpens) //in this case it is a mineral vein
     {
-        uint32 entrynew;
-        entrynew = RollMineralVein(GetRealEntry());
+        uint32 entrynew = RollMineralVein(GetRealEntry());
 
         uint32 guid = GetObjectGuid();
 
@@ -1800,7 +1799,7 @@ void GameObject::RollIfMineralVein()
 
 uint32 GameObject::RollMineralVein(uint32 entry)      //Maybe incedicite bloodstone and indurium have alternate spawns?
 {
-    uint32 entrynew;
+    uint32 entrynew = entry;
     switch (entry)
     {
         case 1732: // Tin can spawn Silver

--- a/src/game/Group.cpp
+++ b/src/game/Group.cpp
@@ -959,6 +959,23 @@ void Group::CountTheRoll(Rolls::iterator& rollI)
     delete roll;
 }
 
+bool Group::IsRollDoneForItem(Creature * pCreature, const LootItem * pItem)
+{
+	if(RollId.empty())
+		{ return true; }
+
+	Roll * roll;
+
+	for(Rolls::iterator i = RollId.begin(); i != RollId.end(); i++)
+	{
+		roll = *i;
+		if(roll->lootedTargetGUID == pCreature->GetObjectGuid() && roll->itemid == pItem->itemid)
+			{ return false; }
+	}
+
+	return true;
+}
+
 void Group::SetTargetIcon(uint8 id, ObjectGuid targetGuid)
 {
     if (id >= TARGET_ICON_COUNT)

--- a/src/game/Group.h
+++ b/src/game/Group.h
@@ -302,11 +302,11 @@ class MANGOS_DLL_SPEC Group
 		* \param guid GUID of the player to look for.
 		* \return time_t representing the joined time for that player or NULL if it doesn't exist.
 		*/
-		time_t const& GetMemberSlotJoinedTime(ObjectGuid guid)
+		time_t GetMemberSlotJoinedTime(ObjectGuid guid)
 		{
 			member_citerator mslot = _getMemberCSlot(guid);
 			if(mslot == m_memberSlots.end())
-				{ return NULL; }
+				{ return 0; }
 
 			return mslot->joinTime;
 		}
@@ -400,6 +400,14 @@ class MANGOS_DLL_SPEC Group
         bool CountRollVote(Player* player, ObjectGuid const& lootedTarget, uint32 itemSlot, RollVote vote);
         void StartLootRoll(WorldObject* lootTarget, LootMethod method, Loot* loot, uint8 itemSlot);
         void EndRoll();
+
+		/**
+		* function that returns whether the roll is done for this group for the given creature and the given item.
+		* \param Creature pointer to the creature which has dropped some loots.
+		* \param Item pointer to the item to check.
+		* \return bool true if the roll is done, false otherwise.
+		*/
+		bool IsRollDoneForItem(Creature * pCreature, const LootItem * pItem);
 
         void LinkMember(GroupReference* pRef)
         {

--- a/src/game/LootMgr.cpp
+++ b/src/game/LootMgr.cpp
@@ -436,9 +436,18 @@ LootSlotType LootItem::GetSlotTypeForSharedLoot(PermissionTypes permission, Play
         case OWNER_PERMISSION:
             return LOOT_SLOT_NORMAL;
         case GROUP_PERMISSION:
-            return (is_blocked || is_underthreshold) ? LOOT_SLOT_NORMAL : LOOT_SLOT_VIEW;
+		{
+			/// The roll for this item has been done.
+			if (is_underthreshold || winner || viewer->GetGroup()->IsRollDoneForItem((Creature *)lootTarget, this))
+				{ return LOOT_SLOT_NORMAL; }
+			
+			return LOOT_SLOT_VIEW;			
+		}
         case MASTER_PERMISSION:
-            return !is_underthreshold ? LOOT_SLOT_MASTER : LOOT_SLOT_NORMAL;
+			if (winner || is_underthreshold || viewer->GetObjectGuid() != viewer->GetGroup()->GetLooterGuid() || winner == viewer->GetObjectGuid())
+				{ return LOOT_SLOT_NORMAL; }
+			
+			return LOOT_SLOT_MASTER;
         default:
             return MAX_LOOT_SLOT_TYPE;
     }

--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -7438,20 +7438,11 @@ void Player::SendLoot(ObjectGuid guid, LootType loot_type)
 									permission = ALL_PERMISSION;
 									break;
 								case MASTER_LOOT:
-									if(group->GetLooterGuid() == GetObjectGuid())
-										{ permission = MASTER_PERMISSION; } 
-									else 
-										{ permission = (creature->hasBeenLootedOnce ? ALL_PERMISSION : GROUP_PERMISSION); }
+									permission = MASTER_PERMISSION;
 									break;
 								case GROUP_LOOT:
 								case NEED_BEFORE_GREED:
 									permission = GROUP_PERMISSION;
-									
-									if(loot->IsWinner(this))
-									{
-										permission = OWNER_PERMISSION;
-									}
-
 									break;
 							}
                         }


### PR DESCRIPTION
- Fixing bugs on loot handler for groups looting modes.
- Send now message to the client whenever he must not be able to pick-up the loot.
- When assigned to a player, an item in master loot mode can't be stolen anymore.
- When a roll is won by a player for a given object, nobody else can get the loot anymore.
- Fixing a core crash bug with Roll for Rare Vein mechanism.
