### PR TITLE
Fixing Group Loot bugs

### DIFF
--- a/src/game/LootHandler.cpp
+++ b/src/game/LootHandler.cpp
@@ -142,6 +142,7 @@ void WorldSession::HandleAutostoreLootItemOpcode(WorldPacket& recv_data)
 					player->SendEquipError(EQUIP_ERR_LOOT_CANT_LOOT_THAT_NOW, NULL, NULL, item->itemid);
 					return;
 				}
+				break;
 			}
 			case MASTER_LOOT:
 			{
@@ -150,6 +151,7 @@ void WorldSession::HandleAutostoreLootItemOpcode(WorldPacket& recv_data)
 					player->SendEquipError(EQUIP_ERR_LOOT_CANT_LOOT_THAT_NOW, NULL, NULL, item->itemid);
 					return;
 				}
+				break;
 			}
 		}
 	}
@@ -506,9 +508,28 @@ void WorldSession::DoLootRelease(ObjectGuid lguid)
 			if(!loot->isLooted())
 			{ 
 				Group const* group = pCreature->GetGroupLootRecipient();
-				// Checking whether it has been looted once by the designed looter (master loot case).
-				pCreature->hasBeenLootedOnce = (group ? group->GetLooterGuid() == player->GetObjectGuid() : true);	
-				pCreature->MarkFlagUpdateForClient(UNIT_DYNAMIC_FLAGS);
+				if(group && !pCreature->hasBeenLootedOnce)
+				{
+					// Checking whether it has been looted once by the designed looter (master loot case).
+					switch(group->GetLootMethod())
+					{
+						case FREE_FOR_ALL:
+						case NEED_BEFORE_GREED:
+						case ROUND_ROBIN:
+						case GROUP_LOOT:
+						{
+							pCreature->hasBeenLootedOnce = true;
+							break;
+						}
+						case MASTER_LOOT:
+						{
+							pCreature->hasBeenLootedOnce = (group->GetLooterGuid() == player->GetObjectGuid());
+							break;
+						}
+
+					}
+					pCreature->MarkFlagUpdateForClient(UNIT_DYNAMIC_FLAGS);
+				}
 			}			
 
             /* We've completely looted the creature, mark it as available for skinning */


### PR DESCRIPTION
- When people are in group, quest items were not pickable because of missing break.
- When people are in group, not in master loot mode, the creatures which have been looted once may not be accessible to other like it should have been.

Bot of them are now fixed.
