### PR TITLE
Fixing Master Loot for already assigned item to players who had full bags

### DIFF
--- a/src/game/LootHandler.cpp
+++ b/src/game/LootHandler.cpp
@@ -611,7 +611,9 @@ void WorldSession::HandleLootMasterGiveOpcode(WorldPacket& recv_data)
 		// Assign winner to the item, avoiding other member picks it up.
 		item.winner = target->GetObjectGuid();
         target->SendEquipError(msg, NULL, NULL, item.itemid);
-		
+
+		pLoot->NotifyItemRemoved(slotid);
+
         return;
     }
 

--- a/src/game/LootMgr.cpp
+++ b/src/game/LootMgr.cpp
@@ -444,7 +444,11 @@ LootSlotType LootItem::GetSlotTypeForSharedLoot(PermissionTypes permission, Play
 			return LOOT_SLOT_VIEW;			
 		}
         case MASTER_PERMISSION:
-			if (winner || is_underthreshold || viewer->GetObjectGuid() != viewer->GetGroup()->GetLooterGuid() || winner == viewer->GetObjectGuid())
+			// If we're not the winner, the item won't show up anymore.
+			if (winner && winner != viewer->GetObjectGuid())
+				{ return MAX_LOOT_SLOT_TYPE; }
+
+			if (is_underthreshold || viewer->GetObjectGuid() != viewer->GetGroup()->GetLooterGuid() || winner == viewer->GetObjectGuid())
 				{ return LOOT_SLOT_NORMAL; }
 			
 			return LOOT_SLOT_MASTER;


### PR DESCRIPTION
A bug was still present, master looters assigning items to players with full inventory
were still able to change the target if they wanted to. Now, only the winner will be able
to pick up the loot once it's assigned.
