### PR TITLE
Fixing group loot issue + chest loot issues

### DIFF
--- a/src/game/GameObject.cpp
+++ b/src/game/GameObject.cpp
@@ -392,15 +392,6 @@ void GameObject::Update(uint32 update_diff, uint32 p_time)
                     if (GetGOInfo()->GetAutoCloseTime() && (m_cooldownTime < time(NULL)))
                         { ResetDoorOrButton(); }
                     break;
-                case GAMEOBJECT_TYPE_CHEST:
-                    if (m_groupLootId)
-                    {
-                        if (m_groupLootTimer <= update_diff)
-                            { StopGroupLoot(); }
-                        else
-                            { m_groupLootTimer -= update_diff; }
-                    }
-                    break;
                 case GAMEOBJECT_TYPE_GOOBER:
                     if (m_cooldownTime < time(NULL))
                     {

--- a/src/game/Group.cpp
+++ b/src/game/Group.cpp
@@ -630,8 +630,8 @@ void Group::GroupLoot(WorldObject* pSource, Loot* loot)
             continue;
         }
 
-        // roll for over-threshold item if it's one-player loot
-        if (itemProto->Quality >= uint32(m_lootThreshold) && !lootItem.freeforall)
+		// Roll for creature drops only. Not for other containers.
+		if (itemProto->Quality >= uint32(m_lootThreshold) && !lootItem.freeforall && pSource->GetTypeId() == TYPEID_UNIT)
             { StartLootRoll(pSource, GROUP_LOOT, loot, itemSlot); }
         else
             { lootItem.is_underthreshold = 1; }
@@ -651,7 +651,7 @@ void Group::NeedBeforeGreed(WorldObject* pSource, Loot* loot)
         }
 
         // only roll for one-player items, not for ones everyone can get
-        if (itemProto->Quality >= uint32(m_lootThreshold) && !lootItem.freeforall)
+		if (itemProto->Quality >= uint32(m_lootThreshold) && !lootItem.freeforall && pSource->GetTypeId() == TYPEID_UNIT)
             { StartLootRoll(pSource, NEED_BEFORE_GREED, loot, itemSlot); }
         else
             { lootItem.is_underthreshold = 1; }
@@ -969,7 +969,7 @@ bool Group::IsRollDoneForItem(Creature * pCreature, const LootItem * pItem)
 	for(Rolls::iterator i = RollId.begin(); i != RollId.end(); i++)
 	{
 		roll = *i;
-		if(roll->lootedTargetGUID == pCreature->GetObjectGuid() && roll->itemid == pItem->itemid)
+		if(roll->lootedTargetGUID == pCreature->GetObjectGuid() && roll->itemid == pItem->itemid && roll->totalPlayersRolling > 1)
 			{ return false; }
 	}
 

--- a/src/game/LootHandler.cpp
+++ b/src/game/LootHandler.cpp
@@ -434,7 +434,10 @@ void WorldSession::DoLootRelease(ObjectGuid lguid)
             }
             else
                 // not fully looted object
-                { go->SetLootState(GO_ACTIVATED); }
+            { 
+				go->SetLootState(GO_ACTIVATED); 
+				go->SetGoState(GO_STATE_READY);
+			}
             break;
         }
         /* Only used for removing insignia in battlegrounds */

--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -4792,6 +4792,10 @@ SpellCastResult Spell::CheckCast(bool strict)
                 uint32 lockId = 0;
                 if (GameObject* go = m_targets.getGOTarget())
                 {
+					// Prevent opening two times a chest in same time.
+					if (go->GetGoType() == GAMEOBJECT_TYPE_CHEST && go->GetGoState() == GO_STATE_ACTIVE)
+						{ return SPELL_FAILED_CHEST_IN_USE; }
+
                     // In BattleGround players can use only flags and banners
                     if (((Player*)m_caster)->InBattleGround() &&
                         !((Player*)m_caster)->CanUseBattleGroundObject())


### PR DESCRIPTION
- Single players in group looting object above the quality of the treshold must now be able to loot them.
- Chests will now be excluded from the roll system, but not from the master loot system.
- Chests will now appear as "open" when a player has open it. Client will now display an error message in such case.
- Two players won't be able to open a chest simultanesouly like it was the case.
- Players will now appear as "looting" to other players while looting a chest.
