### PR TITLE
Fixing Chest Loot Issue

### DIFF
--- a/src/game/LootHandler.cpp
+++ b/src/game/LootHandler.cpp
@@ -436,8 +436,10 @@ void WorldSession::DoLootRelease(ObjectGuid lguid)
                 // not fully looted object
             { 
 				go->SetLootState(GO_ACTIVATED); 
-				go->SetGoState(GO_STATE_READY);
 			}
+
+            go->SetGoState(GO_STATE_READY);
+
             break;
         }
         /* Only used for removing insignia in battlegrounds */

--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -4831,7 +4831,8 @@ SpellCastResult Spell::CheckCast(bool strict)
 
                 // chance for fail at orange mining/herb/LockPicking gathering attempt
                 // second check prevent fail at rechecks
-                if (skillId != SKILL_NONE && (!m_selfContainer || ((*m_selfContainer) != this)))
+                // Check must be executed at the end of  the cast.
+                if (m_executedCurrently && skillId != SKILL_NONE)
                 {
                     bool canFailAtMax = skillId != SKILL_HERBALISM && skillId != SKILL_MINING;
 


### PR DESCRIPTION
- Fixing a bug that would made a vein/plant unlootable after one loot.
- Fixing a bug that would report "Failed try" to the client at the beginning of the mining/gathering action.
