### PR TITLE
Build warning eliminated (storing int in bool)

### DIFF
--- a/src/tools/map-extractor/System.cpp
+++ b/src/tools/map-extractor/System.cpp
@@ -209,7 +209,7 @@ bool HandleArgs(int argc, char** argv)
             int convertFloatToInt = atoi(param);
             if (convertFloatToInt != 0)
             {
-                CONF_allow_float_to_int = convertFloatToInt;
+                CONF_allow_float_to_int = true;
             }
         }
         else if (strcmp(argv[i], "-e") == 0 || strcmp(argv[i], "--extract") == 0)


### PR DESCRIPTION
Original code attempted to copy the contents of an integer variable into
a boolean variable.

Seeing as the check is for NOT equal to 0 (FALSE), the contents of the
boolean (CONF_allow_float_to_int) will be TRUE, therefore you might as
well explicitly state the this instead of attempting to force it.
