### PR TITLE
Reversing the quiver fix in the server core

### DIFF
--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -7709,7 +7709,6 @@ uint8 Player::FindEquipSlot(ItemPrototype const* proto, uint32 slot, bool swap) 
             slots[0] = EQUIPMENT_SLOT_RANGED;
             break;
         case INVTYPE_BAG:
-		case INVTYPE_QUIVER:
             slots[0] = INVENTORY_SLOT_BAG_START + 0;
             slots[1] = INVENTORY_SLOT_BAG_START + 1;
             slots[2] = INVENTORY_SLOT_BAG_START + 2;


### PR DESCRIPTION
Previous fix proved to be incorrect due to the fact the INVTYPE_BAG is
the bag slot where things like bags, quivers, and ammo pouches go.
