### PR TITLE
Cuergo's Gold quest fix

### DIFF
--- a/src/modules/SD2/scripts/kalimdor/tanaris.cpp
+++ b/src/modules/SD2/scripts/kalimdor/tanaris.cpp
@@ -503,9 +503,71 @@ bool QuestAccept_npc_tooga(Player* pPlayer, Creature* pCreature, const Quest* pQ
     return true;
 }
 
+/*######
+## go_inconspicuous_landmark
+## This is for Cuergo's Gold quest
+######*/
+
+enum
+{
+    NPC_TREASURE_HUNTING_PIRATE = 7899,
+    NPC_TREASURE_HUNTING_SWASHBUCKLER = 7901,
+    NPC_TREASURE_HUNTING_BUCCANEER = 7902,
+    GO_PIRATE_TREASURE = 142194,
+    SPAWN_DURATION = 600000 // pirates and chest will exist in world for 10 minutes
+};
+
+bool GOUse_go_pirate_treasure(Player* pPlayer, GameObject* pGo)
+{
+    // despawn chest
+    pGo->SetSpawnedByDefault(false);
+    pGo->SetRespawnTime(10); 
+    
+    return true;
+}
+
+void SpawnPirates(Player* pPlayer, uint iNumberOfPirates)
+{
+    for (int i; i<iNumberOfPirates; i++)
+    {
+        // spawn 4 or 5 sailor boys
+        switch (urand(0, 2))
+        {    
+            case 0: // spawn treasure hunting pirate
+                pPlayer->SummonCreature(NPC_TREASURE_HUNTING_PIRATE, 0.0f, 0.0f, 0.0f, 0.0f, TEMPSUMMON_TIMED_DESPAWN, SPAWN_DURATION);
+                break;
+            case 1: // spawn treasure hunting swashbuckler
+                pPlayer->SummonCreature(NPC_TREASURE_HUNTING_SWASHBUCKLER, 0.0f, 0.0f, 0.0f, 0.0f, TEMPSUMMON_TIMED_DESPAWN, SPAWN_DURATION);
+                break;
+            default: // spawn treasure hunting buccaneer
+                pPlayer->SummonCreature(NPC_TREASURE_HUNTING_BUCCANEER, 0.0f, 0.0f, 0.0f, 0.0f, TEMPSUMMON_TIMED_DESPAWN, SPAWN_DURATION);
+                break;
+        }
+    }
+}
+
+bool GOUse_go_inconspicuous_landmark(Player* pPlayer, GameObject* pGo)
+{
+    // spawn 4 or 5 sailor boys
+    SpawnPirates(pPlayer, urand(4, 5));
+
+    // spawn chest
+    pPlayer->SummonGameObject(GO_PIRATE_TREASURE, -10117.715, -4051.644, 5.407, 0.0f, SPAWN_DURATION);
+    return true;
+}
 void AddSC_tanaris()
 {
     Script* pNewScript;
+
+    pNewScript = new Script;
+    pNewScript->Name = "go_pirate_treasure";
+    pNewScript->pGOUse = &GOUse_go_pirate_treasure;
+    pNewScript->RegisterSelf();
+
+    pNewScript = new Script;
+    pNewScript->Name = "go_inconspicuous_landmark";
+    pNewScript->pGOUse = &GOUse_go_inconspicuous_landmark;
+    pNewScript->RegisterSelf();
 
     pNewScript = new Script;
     pNewScript->Name = "mob_aquementas";


### PR DESCRIPTION
The pirates and treasure chest were not spawning, thus resulting in the
quest not being completable.

This script spawns the pirates and the chest.
