### PR TITLE
[Core][805] Unified method of Shield Slam spell recongizing

### DIFF
--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -4040,7 +4040,7 @@ SpellCastResult Spell::CheckCast(bool strict)
             }
         }
 
-        if (!(m_spellInfo->SpellIconID == 413 && m_spellInfo->Category == 971)) // the Shield Slam does not depend on its dispel effect
+        if (!(m_spellInfo->SpellFamilyName == SPELLFAMILY_WARRIOR && m_spellInfo->SpellFamilyFlags & UI64LIT(0x100000000))) // the Shield Slam does not depend on its dispel effect
         {
             // Fill possible dispel list
             bool isDispell = false;

--- a/src/game/WorldHandlers/SpellEffects.cpp
+++ b/src/game/WorldHandlers/SpellEffects.cpp
@@ -337,7 +337,7 @@ void Spell::EffectSchoolDMG(SpellEffectIndex effect_idx)
                     damage = uint32(damage * (m_caster->GetTotalAttackPowerValue(BASE_ATTACK)) / 100);
                 }
                 // Shield Slam
-                else if (m_spellInfo->SpellIconID == 413 && m_spellInfo->SpellFamilyFlags & UI64LIT(0x2000000))
+                else if (m_spellInfo->SpellFamilyFlags & UI64LIT(0x100000000))
                     { damage += int32(m_caster->GetShieldBlockValue()); }
                 break;
             }


### PR DESCRIPTION
The way of recognizing Shield Slam spell is unified throughout the core: SpellFamilyName and SpellFamilyFlags. An excessive check is removed.
This is a minor code improvement, not a bugfix. Its OK for One too.
