### PR TITLE
Learning Master Sword/Axe/Hammer skill spell corrections

### DIFF
--- a/src/modules/SD2/scripts/world/npc_professions.cpp
+++ b/src/modules/SD2/scripts/world/npc_professions.cpp
@@ -115,9 +115,9 @@
 
 #define S_LEARN_WEAPON          9789
 #define S_LEARN_ARMOR           9790
-#define S_LEARN_HAMMER          39099
-#define S_LEARN_AXE             39098
-#define S_LEARN_SWORD           39097
+#define S_LEARN_HAMMER          17044
+#define S_LEARN_AXE             17043
+#define S_LEARN_SWORD           17042
 
 #define S_UNLEARN_WEAPON        36436
 #define S_UNLEARN_ARMOR         36435


### PR DESCRIPTION
Correct spells added for learning Master Swordsmith/Axesmith/Hammersmith
Vanilla

-- the npc_professions.cpp still needs to major overhaul for Vanills
