### PR TITLE
[879][mangosd] Change Win32 behavior at abort() not blocking restart

### DIFF
--- a/src/game/Object/Creature.cpp
+++ b/src/game/Object/Creature.cpp
@@ -650,7 +650,7 @@ void Creature::RegenerateAll(uint32 update_diff)
 
 void Creature::RegeneratePower()
 {
-    if (!IsRegeneratingPower())
+    if (!IsRegeneratingPower() && !IsPet())
         return;
 
     Powers powerType = GetPowerType();

--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -15950,12 +15950,15 @@ void Player::LogWhisper(const std::string& text, ObjectGuid receiver)
     
     if ((loggingLevel == WHISPER_LOGGING_TICKETS && ticket && isSomeoneGM)
         || loggingLevel == WHISPER_LOGGING_EVERYTHING)
-        CharacterDatabase.PExecute("INSERT INTO character_whispers "
-                                   "(to_guid, from_guid, message, regarding_ticket_id) "
-                                   "VALUES "
-                                   "(%u,      %u,        '%s',    %d)",
-                                   receiver.GetCounter(), GetObjectGuid().GetCounter(),
-                                   text.c_str(), ticketId);
+    {
+        static SqlStatementID wlog;
+        SqlStatement stmt = CharacterDatabase.CreateStatement(wlog, "INSERT INTO character_whispers (to_guid, from_guid, message, regarding_ticket_id) VALUES (?, ?, ?, ?)");
+        stmt.addUInt32(receiver.GetCounter());          // to_guid
+        stmt.addUInt32(GetObjectGuid().GetCounter());   // from_guid
+        stmt.addString(text.c_str());                   // message
+        stmt.addUInt32(ticketId);                       // regarding_ticket_id
+        stmt.Execute();
+    }
 }
 
 void Player::Whisper(const std::string& text, uint32 language, ObjectGuid receiver)

--- a/src/mangosd/Main.cpp
+++ b/src/mangosd/Main.cpp
@@ -211,7 +211,13 @@ extern int main(int argc, char** argv)
 
     ///- and run the 'Master'
     /// \todo Why do we need this 'Master'? Can't all of this be in the Main as for Realmd?
-    return sMaster.Run();
+    int code = sMaster.Run();
+
+#ifdef WIN32
+    _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+#endif
+
+    return code;
 
     // at sMaster return function exist with codes
     // 0 - normal shutdown


### PR DESCRIPTION
- This is rather a crude workaround, though the program design allows it.
  Other Win builds, in particular 64-bit, should be tested and the code extended accordingly by additional defines, if any.
- Merge is void, ignore it.
- Pet power regen [588], should be checked for non-player pets.
- Switch to prepared statement for a correct string SQL escape (whisper logging).
