### PR TITLE
Mr Smite Weapon Correction

### DIFF
--- a/src/modules/SD2/scripts/eastern_kingdoms/deadmines/boss_mr_smite.cpp
+++ b/src/modules/SD2/scripts/eastern_kingdoms/deadmines/boss_mr_smite.cpp
@@ -40,7 +40,7 @@ enum
     SAY_PHASE_2                     = -1036002,
     SAY_PHASE_3                     = -1036003,
 
-    // EQUIP_ID_SWORD               = 2179,                 // default equipment, not used in code
+    EQUIP_ID_SWORD                  = 2179,                 // default equipment, not used in code
     EQUIP_ID_AXE                    = 2183,
     EQUIP_ID_HAMMER                 = 10756,
 
@@ -76,7 +76,8 @@ struct boss_mr_smiteAI : public ScriptedAI
         DoCastSpellIfCan(m_creature, SPELL_NIBLE_REFLEXES, CAST_TRIGGERED);
 
         // must assume database has the default equipment set
-        SetEquipmentSlots(true);
+//      SetEquipmentSlots(true);
+        SetEquipmentSlots(false, EQUIP_ID_SWORD, EQUIP_UNEQUIP);
     }
 
     void AttackedBy(Unit* pAttacker) override

--- a/src/modules/SD2/scripts/eastern_kingdoms/deadmines/boss_mr_smite.cpp
+++ b/src/modules/SD2/scripts/eastern_kingdoms/deadmines/boss_mr_smite.cpp
@@ -40,7 +40,7 @@ enum
     SAY_PHASE_2                     = -1036002,
     SAY_PHASE_3                     = -1036003,
 
-    EQUIP_ID_SWORD                  = 2179,                 // default equipment, not used in code
+    EQUIP_ID_SWORD                  = 2179,                 // default equipment
     EQUIP_ID_AXE                    = 2183,
     EQUIP_ID_HAMMER                 = 10756,
 


### PR DESCRIPTION
The weapon he wields after he got spawned was wrong (2h mace). It was
supposed to be a 1h sword.
